### PR TITLE
EditInfoActivity.kt 비밀번호 수정 관련 편의성 개선 및 기타 수정

### DIFF
--- a/app/src/main/java/com/busanit/searchrestroom/dao/MemberDao.kt
+++ b/app/src/main/java/com/busanit/searchrestroom/dao/MemberDao.kt
@@ -25,10 +25,10 @@ interface MemberDao {
 
   // 닉네임 업데이트
   @Query("UPDATE member SET nickname = :newNickname WHERE member_id = :memberId")
-  fun updateNickname(memberId: Int, newNickname: String)
+  suspend fun updateNickname(memberId: Int, newNickname: String)
 
   // 비밀번호 업데이트
   @Query("UPDATE member SET password = :newPassword WHERE member_id = :memberId")
-  fun updatePassword(memberId: Int, newPassword: String)
+  suspend fun updatePassword(memberId: Int, newPassword: String)
 
 }

--- a/app/src/main/java/com/busanit/searchrestroom/myPage/EditInfoActivity.kt
+++ b/app/src/main/java/com/busanit/searchrestroom/myPage/EditInfoActivity.kt
@@ -162,11 +162,8 @@ class EditInfoActivity : AppCompatActivity() {
             }
         }
 
-        // 바꿀 비밀번호가 비어있거나 기존 비밀번호와 같으면 리턴
-        if (newPassword.isEmpty()) {
-            Toast.makeText(this, "새 비밀번호를 입력해주세요.", Toast.LENGTH_SHORT).show()
-            return
-        } else if (newPassword == currentPassword) {
+        // 바꿀 비밀번호가 기존 비밀번호와 같으면 리턴(빈 값일 때는 그냥 넘김)
+         if (newPassword == currentPassword) {
             Toast.makeText(this, "새 비밀번호는 기존 비밀번호와 달라야 합니다!", Toast.LENGTH_SHORT).show()
             return
         }
@@ -174,6 +171,7 @@ class EditInfoActivity : AppCompatActivity() {
         // 데이터베이스 업데이트 로직
         CoroutineScope(Dispatchers.IO).launch {
             val db = AppDatabase.getDatabase(this@EditInfoActivity)
+
             db!!.memberDao().updateNickname(currentMember!!.memberId, newNickname)    // 닉네임 업데이트
             if (newPassword.isNotEmpty()) {
                 if (newPassword != currentPassword) {
@@ -182,13 +180,11 @@ class EditInfoActivity : AppCompatActivity() {
                     Toast.makeText(this@EditInfoActivity, "새 비밀번호는 기존 비밀번호와 달라야 합니다!", Toast.LENGTH_SHORT).show()
                     return@launch
                 }
-            } else {
-                Toast.makeText(this@EditInfoActivity, "새 비밀번호를 입력해주세요.", Toast.LENGTH_SHORT).show()
-                return@launch
             }
 
             withContext(Dispatchers.Main) {
                 Toast.makeText(this@EditInfoActivity, "정보가 수정되었습니다.", Toast.LENGTH_SHORT).show()
+                setResult(RESULT_OK)    // 결과 설정
                 finish()  // 수정 후 액티비티 종료
             }
         }

--- a/app/src/main/java/com/busanit/searchrestroom/myPage/MyPageActivity.kt
+++ b/app/src/main/java/com/busanit/searchrestroom/myPage/MyPageActivity.kt
@@ -1,5 +1,6 @@
 package com.busanit.searchrestroom.myPage
 
+import android.app.ComponentCaller
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
@@ -36,6 +37,17 @@ class MyPageActivity : AppCompatActivity() {
     private lateinit var memberDao: MemberDao
     private var currentMember: Member? = null
     private lateinit var userRepository: UserRepository
+
+    companion object {
+        private const val EDIT_INFO_REQUEST_CODE = 1
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?, ) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == EDIT_INFO_REQUEST_CODE && resultCode == RESULT_OK) {
+            loadUserInfo()  // 사용자 정보 새롭게 로드
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -85,7 +97,7 @@ class MyPageActivity : AppCompatActivity() {
 
         binding.editIcon.setOnClickListener {
             if (AuthHelper.isLoggedIn()) {
-                startActivity(Intent(this, EditInfoActivity::class.java))
+                startActivityForResult(Intent(this, EditInfoActivity::class.java), EDIT_INFO_REQUEST_CODE)   // 요청 코드 전달
             } else {
                 showToast("로그인이 필요합니다.")
                 // 로그인 화면으로 이동
@@ -155,6 +167,7 @@ class MyPageActivity : AppCompatActivity() {
 
     private fun logout() {
         AuthHelper.logout()
+        currentMember = null    // 로그아웃 후 currentMember 초기화
         updateUI()
     }
 


### PR DESCRIPTION
- 회원정보 수정 단계에서 기존 비밀번호는 입력받되, 닉네임만 바꾸는 경우를 위해 새 비밀번호란이 빈값이어도 정보 수정이 되게끔 개선
- 그 과정에서 수정된 닉네임 정보가 바로 마이페이지에 적용되지 않는 문제점을 발견해 이 또한 수정